### PR TITLE
fix(docker): secure environment files in Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
 FROM nginx:1.25.3-alpine
 
-WORKDIR /var/www/codesandbox
-COPY www ./
+# Nginx config: serves /usr/share/nginx/html and denies dotfiles (e.g. /.env).
+COPY .github/nginx/default.conf /etc/nginx/conf.d/default.conf
+
+# Static assets go under the document root.
+COPY www /usr/share/nginx/html
+
+# Runtime env template + generator live OUTSIDE the document root so they are
+# never reachable over HTTP. `env.sh` reads `.env` (and any overriding real
+# environment variables) and writes `env-config.js` into the served static dir.
+COPY .env /app/.env
+COPY env.sh /app/env.sh
+RUN chmod +x /app/env.sh
+
+# Defense-in-depth: make absolutely sure no stale copy of .env slipped into
+# the web root from a previous build.
+RUN rm -f /usr/share/nginx/html/.env /usr/share/nginx/html/env.sh
+
+WORKDIR /app
+
+# Generate env-config.js at container start, then hand off to nginx (PID 1).
+CMD ["/bin/sh", "-c", "/app/env.sh /usr/share/nginx/html/static/js/env-config.js && exec nginx -g 'daemon off;'"]

--- a/packages/app/scripts/copy-assets.js
+++ b/packages/app/scripts/copy-assets.js
@@ -24,14 +24,13 @@ const assets = [
     from: 'packages/app/public',
     to: '',
   },
-  {
-    from: '.env',
-    to: '.env',
-  },
-  {
-    from: 'env.sh',
-    to: 'env.sh',
-  },
+  // NOTE: `.env` and `env.sh` are intentionally NOT copied into `www/`.
+  // `www/` is served publicly by nginx, so anything placed here is reachable
+  // from the internet (e.g. GET /.env would leak secrets). `env.sh` reads
+  // `.env` at container startup to generate `static/js/env-config.js`, which
+  // is the only file the browser needs. The Dockerfile places `.env` and
+  // `env.sh` under `/app` (outside the document root) and runs `env.sh` from
+  // there on container start.
 ].filter(Boolean);
 
 const rootPath = path.resolve(__dirname, '../../..');


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Prevent copying of `.env` and `env.sh` into the public `www/` directory.
* Ensure sensitive files are stored outside the document root to avoid exposure.
* Update comments for clarity on the handling of environment variables.

## What is the current behavior?

When one does leverage this sandbox to use Artifacts in Librechat is also exposing the .env file.
I know that the API_KEY in it it's not that critical, but for an attacker is enough to know what's installed and how to get in.

_As enterprises goes, this is a **critical** issue._

## What is the new behavior?

It wont copy the .env into www/ directory

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
